### PR TITLE
fix: prevent infinite recursion caused by certificate self-referencing

### DIFF
--- a/cert_chain_resolver/models.py
+++ b/cert_chain_resolver/models.py
@@ -215,6 +215,7 @@ class CertificateChain:
     def __init__(self, chain=None):
         # type: (Union[Optional[CertificateChain], List[Cert]]) -> None
         self._chain = [] if not chain else list(chain)  # type: List[Cert]
+        self._fingerprints = set() if not chain else { x509_obj.fingerprint for x509_obj in chain }
 
     def __iter__(self):
         # type: () -> Iterator[Cert]
@@ -224,11 +225,16 @@ class CertificateChain:
     def __iadd__(self, x509_obj):
         # type: (Cert) -> CertificateChain
         self._chain.append(x509_obj)
+        self._fingerprints.add(x509_obj.fingerprint)
         return self
 
     def __len__(self):
         # type: () -> int
         return self._chain.__len__()
+
+    def __contains__(self, x509_obj):
+        # type: (Cert) -> bool
+        return self._fingerprints.__contains__(x509_obj.fingerprint)
 
     @property
     def leaf(self):

--- a/cert_chain_resolver/resolver.py
+++ b/cert_chain_resolver/resolver.py
@@ -42,6 +42,9 @@ def resolve(bytes_cert, _chain=None):
     if not _chain:
         _chain = CertificateChain()
 
+    if cert in _chain:
+        return _chain
+
     _chain += cert
 
     parent_cert = None

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -19,3 +19,20 @@ def test_resolve_works_recursively(monkeypatch, mocker):
 
     chain = resolve(b"hoi")
     assert list(chain) == [leaf, intermediate, ca]
+
+
+def test_resolve_works_avoid_infinite_recursion(monkeypatch, mocker):
+    """Ensure that a certificate with refences to itself can be resolved correctly"""
+    leaf = mocker.Mock()
+
+    resolve_mock = mocker.MagicMock()
+    resolve_mock.side_effect = [leaf, leaf, leaf]
+    monkeypatch.setattr(Cert, "load", resolve_mock)
+
+    monkeypatch.setattr(
+        "cert_chain_resolver.resolver._download",
+        mocker.Mock(side_effect=["leaf", "leaf"]),
+    )
+
+    chain = resolve(b"hoi")
+    assert list(chain) == [leaf]


### PR DESCRIPTION
fix: prevent infinite recursion caused by certificate self-referencing in ca_issuer_access_location